### PR TITLE
Add windows support

### DIFF
--- a/elixir_sublime.py
+++ b/elixir_sublime.py
@@ -43,17 +43,31 @@ def run_mix_task(cmd):
         pass
     if _socket:
         env['ELIXIR_SUBLIME_PORT'] = str(_socket.getsockname()[1])
+
+    if sublime.platform() == "windows":
+        # on Windows, mix is a .bat file, which `subprocess` can't just launch like that. Use cmd.exe to launch the .bat file
+        launcher = ['cmd', '/c', 'mix']
+
+        # don't show the console window
+        startupinfo = subprocess.STARTUPINFO()
+        startupinfo.dwFlags |= subprocess.STARTF_USESHOWWINDOW
+        
+    else:
+        launcher = ['mix']
+        startupinfo = None
+
     return subprocess.Popen( 
-        ['mix'] + cmd.split(), 
+        launcher + cmd.split(), 
         cwd=cwd, 
         stderr=_logfile.fileno(),
         stdout=_logfile.fileno(),
-        env=env)
+        env=env,
+        startupinfo=startupinfo)
 
 
 def find_mix_project(cwd=None):
     cwd = cwd or os.getcwd()   
-    if cwd == '/':
+    if cwd == os.path.realpath('/'):
         return None
     elif os.path.exists(os.path.join(cwd, 'mix.exs')):
         return cwd


### PR DESCRIPTION
Hi! Nice plugin, I wanted to try it but ran into some bugs on Windows.

They were easily avoided, though, so here's a pull request. Things solved:
- `find_mix_project` went into infinite recursion because `/` isn't a Windows path. 
- `mix` is a .bat file on Windows, which you can't just give to Python's `subprocess` like that (which is ridiculous, but that's how it is). The trick is to use `cmd.exe` and suppress the console window that creates.

Note that this is the first time I've ever coded something for Sublime, so if I made stupid mistakes or missed some style guide, please do tell :-)
