### PR TITLE
Improve code completions for application modules

### DIFF
--- a/sublime_completion/lib/sublime_completion.ex
+++ b/sublime_completion/lib/sublime_completion.ex
@@ -43,6 +43,10 @@ defmodule SublimeCompletion do
       ["PATH", path] ->
         path 
           |> Code.append_path
+
+        for app <- Path.wildcard(path <> "/*.app") do
+           app |> Path.basename(".app") |> String.to_atom |> Application.load
+        end
         nil
       ["GOTO", target] ->
         target 


### PR DESCRIPTION
In a phoenix project the completion engine doesn't offer a completion for modules like Phoenix (Postgrex, Eco, ...) and according submodules. I have to write a module name manually.

This patch seems to improve the completions and modules are offered automatically.

I've found this idea at https://github.com/tonini/alchemist-server