### PR TITLE
fix path order

### DIFF
--- a/elixir_sublime.py
+++ b/elixir_sublime.py
@@ -42,7 +42,8 @@ def run_mix_task(cmd):
     cwd = os.path.join(os.path.dirname(__file__), 'sublime_completion')
     env = os.environ.copy()
     try:
-        env['PATH'] += os.pathsep + settings.get('env')['PATH']
+        env['PATH'] = os.pathsep.join(
+            [settings.get('env')['PATH'], env['PATH']])
     except (TypeError, ValueError, KeyError):
         pass
     if _socket:


### PR DESCRIPTION
If the user supplied `PATH` is appended rather than prepended, anything that comes earlier will override the user specified `PATH`.  For example, I have created an [elixir10](https://github.com/Homebrew/homebrew-versions/pull/1006) package for [homebrew-versions](https://github.com/Homebrew/homebrew-versions) to make Elixir `~> 1.0.0` available.   

Currently if the path `/usr/local/opt/elixir10/bin` comes after `/usr/local/bin` and I have the `elixir` homebrew package installed, ElixirSublime will never see the `elixir10` files.  This PR puts the user specified path first so it overrides any other matching items in the path.