### PR TITLE
Remove Shift+MouseDrag mousemapping

### DIFF
--- a/Default (Linux).sublime-mousemap
+++ b/Default (Linux).sublime-mousemap
@@ -1,8 +1,3 @@
 [
-	{
-		"button": "button1",
-		"modifiers": ["shift"],
-		"press_command": "drag_select",
-		"command": "elixir_goto_definition"
-	}
+
 ]

--- a/Default (OSX).sublime-mousemap
+++ b/Default (OSX).sublime-mousemap
@@ -1,8 +1,2 @@
 [
-	{
-		"button": "button1",
-		"modifiers": ["shift"],
-		"press_command": "drag_select",
-		"command": "elixir_goto_definition"
-	}
 ]

--- a/Default (Windows).sublime-mousemap
+++ b/Default (Windows).sublime-mousemap
@@ -1,8 +1,2 @@
 [
-	{
-		"button": "button1",
-		"modifiers": ["shift"],
-		"press_command": "drag_select",
-		"command": "elixir_goto_definition"
-	}
 ]


### PR DESCRIPTION
This shortcut is causing a lot of confusion for users who expect shift+select to work. Solves #8
