### PR TITLE
Fix for Umbrella apps

### DIFF
--- a/elixir_sublime.py
+++ b/elixir_sublime.py
@@ -73,6 +73,8 @@ def find_mix_project(cwd=None):
     cwd = cwd or os.getcwd()   
     if cwd == os.path.realpath('/'):
         return None
+    elif '/apps/' in cwd:
+        return find_mix_project(os.path.dirname(cwd))
     elif os.path.exists(os.path.join(cwd, 'mix.exs')):
         return cwd
     else: 


### PR DESCRIPTION
Currently, this plugin will crash if the Elixir app is structured as an umbrella app.

In an umbrella app, the `_build` directory is nested inside the top level app, not the individual apps. So this PR makes sure the the `find_mix_project` function will keep recursing until it's above the `apps` directory when looking for the directory for the `mix` project.

Here's the error that happens:

```
reloading plugin ElixirSublime.elixir_sublime
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 530, in on_activated_async
    callback.on_activated_async(v)
  File "/Users/vince/Library/Application Support/Sublime Text 3/Packages/ElixirSublime/elixir_sublime.py", line 257, in on_activated_async
    self.on_load_async(view)
  File "/Users/vince/Library/Application Support/Sublime Text 3/Packages/ElixirSublime/elixir_sublime.py", line 262, in on_load_async
    ElixirSession.ensure(os.path.dirname(filename))
  File "/Users/vince/Library/Application Support/Sublime Text 3/Packages/ElixirSublime/elixir_sublime.py", line 162, in ensure
    session.connect()
  File "/Users/vince/Library/Application Support/Sublime Text 3/Packages/ElixirSublime/elixir_sublime.py", line 186, in connect
    for lib_path in find_ebin_folders(self.mix_project):
  File "/Users/vince/Library/Application Support/Sublime Text 3/Packages/ElixirSublime/elixir_sublime.py", line 84, in find_ebin_folders
    for lib in os.listdir(lib_path):
FileNotFoundError: [Errno 2] No such file or directory: '/umbrella_application/apps/some_app/_build/dev/lib'
```